### PR TITLE
feat: add social links and service area in footer

### DIFF
--- a/2023-index.html
+++ b/2023-index.html
@@ -905,7 +905,7 @@ next()
 
 <div class="card-body">
 
-        <p style="margin: 0px; font-size: 12px;">Copyright © SaguaroSec 2021 - 2023 </p>
+        <p style="margin: 0px; font-size: 12px;">&copy; 2021 - 2023 SaguaroSec. Serving Tucson, AZ and surrounding areas.</p>
 
 </div>
 

--- a/about/index.html
+++ b/about/index.html
@@ -553,7 +553,7 @@ particlesJS("particles-js",{particles:{number:{value:50,density:{enable:true,val
 
 <div class="card-body">
 
-        <p style="margin: 0px; font-size: 12px;">Copyright © SaguaroSec 2022 </p>
+        <p style="margin: 0px; font-size: 12px;">&copy; 2022 SaguaroSec. Serving Tucson, AZ and surrounding areas.</p>
 
 </div>
 

--- a/index.html
+++ b/index.html
@@ -12,7 +12,8 @@
   <meta name="keywords" content="Cybersecurity, Consulting, Malware Analysis, Network Monitoring, Risk Management, Tucson, Arizona, Cybersecurity Training, Desktop Application Development">
   
   <link rel='stylesheet' href='https://saguarosec.com/swiper.css'>
-  
+  <link href="https://saguarosec.com/css/all.css" rel="stylesheet">
+
 <style>
 @import url("https://fonts.googleapis.com/css2?family=Comfortaa:wght@700&family=Nunito:wght@300;600&display=swap");
 *,
@@ -107,6 +108,13 @@ footer {
   color: #fff;
   text-decoration: none;
   margin: 0 10px;
+}
+
+.social-icons a {
+  color: #fff;
+  text-decoration: none;
+  margin: 0 10px;
+  font-size: 20px;
 }
 
 .footer-text {
@@ -445,8 +453,12 @@ section {
       <a href="https://saguarosec.com/">Home</a>
       <a href="#">Contact Us</a>
     </div>
+    <div class="social-icons">
+      <a href="https://www.linkedin.com/company/SaguaroSec" target="_blank"><i class="fab fa-linkedin"></i></a>
+      <a href="https://www.facebook.com/SaguaroSec" target="_blank"><i class="fab fa-facebook-square"></i></a>
+    </div>
     <div class="footer-text">
-      &copy; 2024 SAGUAROSEC LLC. All rights reserved.
+      &copy; 2024 SAGUAROSEC LLC. Serving Tucson, AZ and surrounding areas.
     </div>
   </footer>
   </body>

--- a/privacy.html
+++ b/privacy.html
@@ -12,7 +12,8 @@
   <meta name="keywords" content="Cybersecurity, Consulting, Malware Analysis, Network Monitoring, Risk Management, Tucson, Arizona, Cybersecurity Training, Desktop Application Development">
   
   <link rel='stylesheet' href='https://saguarosec.com/swiper.css'>
-  
+  <link href="https://saguarosec.com/css/all.css" rel="stylesheet">
+
 <style>
 @import url("https://fonts.googleapis.com/css2?family=Comfortaa:wght@700&family=Nunito:wght@300;600&display=swap");
 *,
@@ -107,6 +108,13 @@ footer {
   color: #fff;
   text-decoration: none;
   margin: 0 10px;
+}
+
+.social-icons a {
+  color: #fff;
+  text-decoration: none;
+  margin: 0 10px;
+  font-size: 20px;
 }
 
 .footer-text {
@@ -363,8 +371,12 @@ Last updated: 6/4/2024
       <a href="https://saguarosec.com/">Home</a>
       <a href="#">Contact Us</a>
     </div>
+    <div class="social-icons">
+      <a href="https://www.linkedin.com/company/SaguaroSec" target="_blank"><i class="fab fa-linkedin"></i></a>
+      <a href="https://www.facebook.com/SaguaroSec" target="_blank"><i class="fab fa-facebook-square"></i></a>
+    </div>
     <div class="footer-text">
-      &copy; 2024 SAGUAROSEC LLC. All rights reserved.
+      &copy; 2024 SAGUAROSEC LLC. Serving Tucson, AZ and surrounding areas.
     </div>
   </footer>
   </body>

--- a/services/index.html
+++ b/services/index.html
@@ -882,7 +882,7 @@ next()
 
 <div class="card-body">
 
-        <p style="margin: 0px; font-size: 12px;">Copyright © SaguaroSec 2022 </p>
+        <p style="margin: 0px; font-size: 12px;">&copy; 2022 SaguaroSec. Serving Tucson, AZ and surrounding areas.</p>
 
 </div>
 


### PR DESCRIPTION
## Summary
- highlight service coverage in all footer sections
- link to LinkedIn and Facebook from footer

## Testing
- `npm test` *(fails: package.json not found)*

------
https://chatgpt.com/codex/tasks/task_e_688f96115b3c83229ceff4d8335099fa